### PR TITLE
added yarn install which was missing

### DIFF
--- a/src/main/docs/guide/writingTheApp.adoc
+++ b/src/main/docs/guide/writingTheApp.adoc
@@ -27,5 +27,6 @@ Additionally, there is a directory named `client` which contains a React single-
 [source,bash]
 ----
 ~ cd client
+~ yarn install
 ~ yarn start
 ----


### PR DESCRIPTION
Updated the documentation with missing command 'yarn install' that would install the dependencies including react etc before executing start command. Without it I ran into error as the libraries were missing for the app to start